### PR TITLE
UI-435 Textarea - Lightning Component

### DIFF
--- a/lib/components/Textarea/Textarea.js
+++ b/lib/components/Textarea/Textarea.js
@@ -12,6 +12,10 @@ const propTypes = {
    */
   className: PropTypes.string,
   /**
+   * Field uuid
+   */
+  id: PropTypes.string,
+  /**
    * Will mark the component as readOnly
    */
   isReadOnly: PropTypes.bool,
@@ -47,10 +51,6 @@ const propTypes = {
    * The value of the form component
    */
   value: PropTypes.string,
-  /**
-   * Field uuid
-   */
-  id: PropTypes.string,
 };
 
 const defaultProps = {

--- a/lib/components/Textarea/Textarea.js
+++ b/lib/components/Textarea/Textarea.js
@@ -1,59 +1,143 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import { FormElement } from './../Form';
+import classNames from 'classnames';
 import { uuid } from './../utils';
 
-export default class Textarea extends Component {
-  constructor() {
-    super();
-    this.state = { id: `form-element-${uuid()}` };
+const VALID_LENGTHS = ['auto', 'tiny', 'small', 'regular', 'large', 'huge'];
+const VALID_STATES = ['none', 'warning', 'error', 'success'];
 
-    this.onChange = this.onChange.bind(this);
+const propTypes = {
+  /**
+   * ClassName to be added
+   */
+  className: PropTypes.string,
+  /**
+   * Will mark the component as readOnly
+   */
+  isReadOnly: PropTypes.bool,
+  /**
+   * Will mark the component as disabled
+   */
+  isDisabled: PropTypes.bool,
+  /**
+   * Length (width) of the input field, auto = 100%
+   */
+  length: PropTypes.oneOf(VALID_LENGTHS),
+  /**
+   * Name of the field used in form submission
+   */
+  name: PropTypes.string,
+  /**
+   * External onChange event to be fired when the component changes
+   */
+  onValueChange: PropTypes.func,
+  /**
+   * A placeholder string to be displayed before data is entered
+   */
+  placeholder: PropTypes.string,
+  /**
+   * How many rows of text to render by default
+   */
+  rows: PropTypes.number,
+  /**
+   * Validation state for the component
+   */
+  state: PropTypes.oneOf(VALID_STATES),
+  /**
+   * The value of the form component
+   */
+  value: PropTypes.string,
+  /**
+   * Field Error message
+   */
+  error: PropTypes.string,
+  /**
+   * Field is required
+   */
+  required: PropTypes.bool,
+  /**
+   * Field uuid
+   */
+  id: PropTypes.string,
+};
+
+const defaultProps = {
+  className: '',
+  isReadOnly: false,
+  isDisabled: false,
+  length: 'auto',
+  name: null,
+  onValueChange: () => {},
+  placeholder: null,
+  rows: 5,
+  state: 'none',
+  value: '',
+  error: '',
+  required: false,
+};
+
+const determineLengthClass = length =>
+  (VALID_LENGTHS.indexOf(length) > -1 && length !== 'auto' ? `input--${length}` : '');
+
+const determineStateClass = (state) =>
+  (VALID_STATES.indexOf(state) > -1 && state !== 'none' ? `validation-${state}` : '');
+
+class Textarea extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: props.value,
+    };
   }
 
-  onChange(e) {
-    const value = e.target.value;
-    if (this.props.onChange) {
-      this.props.onChange(e, value);
-    }
-  }
+  handleChange = event => {
+    const { onValueChange } = this.props;
+    const value = event.target.value;
+    this.setState({ value },
+      () => {
+        onValueChange(this.state.value);
+      },
+    );
+  };
 
   render() {
-    const id = this.props.id || this.state.id;
-    const { label, required, error, totalCols, cols, ...props } = this.props;
-    if (label || required || error || totalCols || cols) {
-      const formElemProps = { id, label, required, error, totalCols, cols };
-      return (
-        <FormElement {...formElemProps}>
-          <Textarea {...{ ...props, id }} />
-        </FormElement>
-      );
-    }
-    const { className, textareaRef, ...pprops } = props;
-    const taClassNames = classnames(className, 'slds-input');
+    const defaultId = `form-element-${uuid()}`;
+    const { required, error, length, state, className, id = defaultId, name, placeholder,
+      isDisabled, isReadOnly, rows } = this.props;
+    const classesWrapper = classNames(
+      'slds-form-element', // slds class
+      {
+        'slds-has-error': required,
+      },
+    );
+    const classes = classNames(
+      determineLengthClass(length),
+      determineStateClass(state),
+      className,
+      'slds-input', // slds class,
+    );
     return (
-      <textarea
-        id={id}
-        ref={textareaRef}
-        className={taClassNames}
-        onChange={this.onChange}
-        {...pprops}
-      />
+      <div className={classesWrapper}>
+        <textarea
+          id={id}
+          name={name}
+          className={classes}
+          value={this.state.value}
+          onChange={this.handleChange}
+          placeholder={placeholder}
+          disabled={isDisabled}
+          readOnly={isReadOnly}
+          rows={rows}
+        />
+        <span className="slds-form-element__help">{error && error}</span>
+      </div>
     );
   }
 }
 
-Textarea.propTypes = {
-  id: PropTypes.string,
-  className: PropTypes.string,
-  label: PropTypes.string,
-  required: PropTypes.bool,
-  error: FormElement.propTypes.error,
-  totalCols: PropTypes.number,
-  cols: PropTypes.number,
-  onChange: PropTypes.func,
-  textareaRef: PropTypes.func,
-};
+Textarea.propTypes = propTypes;
+Textarea.defaultProps = defaultProps;
 
-Textarea.isFormElement = true;
+Textarea.validStates = VALID_STATES;
+
+export default Textarea;

--- a/lib/components/Textarea/Textarea.js
+++ b/lib/components/Textarea/Textarea.js
@@ -48,14 +48,6 @@ const propTypes = {
    */
   value: PropTypes.string,
   /**
-   * Field Error message
-   */
-  error: PropTypes.string,
-  /**
-   * Field is required
-   */
-  required: PropTypes.bool,
-  /**
    * Field uuid
    */
   id: PropTypes.string,
@@ -93,23 +85,20 @@ class Textarea extends React.PureComponent {
   handleChange = event => {
     const { onValueChange } = this.props;
     const value = event.target.value;
+    event.persist();
     this.setState({ value },
       () => {
-        onValueChange(this.state.value);
+        if (onValueChange) {
+          onValueChange(event);
+        }
       },
     );
   };
 
   render() {
     const defaultId = `form-element-${uuid()}`;
-    const { required, error, length, state, className, id = defaultId, name, placeholder,
+    const { length, state, className, id = defaultId, name, placeholder,
       isDisabled, isReadOnly, rows } = this.props;
-    const classesWrapper = classNames(
-      'slds-form-element', // slds class
-      {
-        'slds-has-error': required,
-      },
-    );
     const classes = classNames(
       determineLengthClass(length),
       determineStateClass(state),
@@ -117,20 +106,17 @@ class Textarea extends React.PureComponent {
       'slds-input', // slds class,
     );
     return (
-      <div className={classesWrapper}>
-        <textarea
-          id={id}
-          name={name}
-          className={classes}
-          value={this.state.value}
-          onChange={this.handleChange}
-          placeholder={placeholder}
-          disabled={isDisabled}
-          readOnly={isReadOnly}
-          rows={rows}
-        />
-        <span className="slds-form-element__help">{error && error}</span>
-      </div>
+      <textarea
+        id={id}
+        name={name}
+        className={classes}
+        value={this.state.value}
+        onChange={this.handleChange}
+        placeholder={placeholder}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+        rows={rows}
+      />
     );
   }
 }

--- a/lib/components/Textarea/Textarea.test.js
+++ b/lib/components/Textarea/Textarea.test.js
@@ -4,6 +4,7 @@ import Textarea from './index';
 
 const mockValue = 'mockValue';
 const mockEvent = {
+  persist: () => ({}),
   target: {
     value: mockValue,
   },
@@ -15,54 +16,53 @@ describe('Textarea', () => {
     const onChangeHandler = jest.fn();
     const component = shallow(<Textarea name="test" onChange={onChangeHandler} />);
     expect(component.length).toBe(1);
-    expect(component.find('.slds-form-element').length).toBe(1);
     expect(component.find('.validation-error').length).toBe(0);
   });
 
   it('renders field length successfully', () => {
     const wrapper = shallow(<Textarea name="test" length="huge" />);
-    expect(wrapper.find('textarea').length).toBe(1);
+    expect(wrapper.length).toBe(1);
     expect(wrapper.find('.input--huge').length).toBe(1);
   });
 
   it('renders validation state successfully', () => {
     const wrapper = shallow(<Textarea name="test" state="error" />);
-    expect(wrapper.find('textarea').length).toBe(1);
+    expect(wrapper.length).toBe(1);
     expect(wrapper.find('.validation-error').length).toBe(1);
   });
 
   it('renders with rows successfully', () => {
     const component = shallow(<Textarea name="test" />);
-    expect(component.find('textarea').prop('rows')).toEqual(5);
+    expect(component.prop('rows')).toEqual(5);
 
     const componentWithRows = shallow(<Textarea name="test" rows={10} />);
-    expect(componentWithRows.find('textarea').prop('rows')).toEqual(10);
+    expect(componentWithRows.prop('rows')).toEqual(10);
   });
 
   it('renders with textarea readonly', () => {
     const component = shallow(<Textarea name="test" isReadOnly />);
-    expect(component.find('textarea').prop('readOnly')).toBe(true);
+    expect(component.prop('readOnly')).toBe(true);
   });
 
   it('renders with textarea disabled', () => {
     const component = shallow(<Textarea name="test" isDisabled />);
-    expect(component.find('textarea').prop('disabled')).toBe(true);
+    expect(component.prop('disabled')).toBe(true);
   });
 
   it('renders textarea with placeholder', () => {
     const component = shallow(<Textarea placeholder="test placeholder" />);
-    expect(component.find('textarea').prop('placeholder')).toEqual('test placeholder');
+    expect(component.prop('placeholder')).toEqual('test placeholder');
   });
 
   it('renders class names with className props', () => {
     const mockClass = 'test-class';
     const component = shallow(<Textarea className={mockClass} />);
-    expect(component.find('textarea').hasClass(mockClass)).toEqual(true);
+    expect(component.hasClass(mockClass)).toEqual(true);
   });
 
   it('onValueChange handler can be invoked', () => {
     const component = shallow(<Textarea name="test" onValueChange={mockChangeHandler} />);
-    component.find('textarea').simulate('change', mockEvent);
+    component.simulate('change', mockEvent);
     setTimeout(() => {
       expect(mockChangeHandler).toBeCalledWith(event);
     }, 0);
@@ -78,8 +78,8 @@ describe('Textarea', () => {
 
   it('onChange handler not to be called if no change happens.', () => {
     const component = shallow(<Textarea name="test" value={mockValue} onValueChange={mockChangeHandler} />);
-    expect(component.find('textarea').prop('value')).toEqual(mockValue);
-    component.find('textarea').simulate('change', mockEvent);
+    expect(component.prop('value')).toEqual(mockValue);
+    component.simulate('change', mockEvent);
     setTimeout(() => {
       expect(mockChangeHandler).not.toBeCalledWith(mockEvent);
     }, 0);
@@ -88,30 +88,30 @@ describe('Textarea', () => {
   it('componentDidUpdate gets called with onValueChange', () => {
     const oldValue = 'oldValue';
     const component = shallow(<Textarea name="test" value={oldValue} onValueChange={mockChangeHandler} />);
-    expect(component.find('textarea').prop('value')).toEqual(oldValue);
+    expect(component.prop('value')).toEqual(oldValue);
     component.setState({ value: mockValue });
     setTimeout(() => {
-      expect(component.find('textarea').prop('value')).toEqual(mockValue);
+      expect(component.prop('value')).toEqual(mockValue);
       expect(mockChangeHandler).toBeCalledWith(mockEvent);
     }, 0);
   });
 
   it('componentDidUpdate does not get called with onValueChange but no value change', () => {
     const component = shallow(<Textarea name="test" value={mockValue} onValueChange={mockChangeHandler} />);
-    expect(component.find('textarea').prop('value')).toEqual(mockValue);
+    expect(component.prop('value')).toEqual(mockValue);
     component.setState({ value: mockValue });
     setTimeout(() => {
-      expect(component.find('textarea').prop('value')).toEqual(mockValue);
+      expect(component.prop('value')).toEqual(mockValue);
       expect(mockChangeHandler).not.toBeCalledWith(mockEvent);
     }, 0);
   });
 
   it('field value matches input value', () => {
     const component = shallow(<Textarea name="test" onValueChange={mockChangeHandler} />);
-    expect(component.find('textarea').text()).toEqual('');
-    component.find('textarea').simulate('change', mockEvent);
+    expect(component.text()).toEqual('');
+    component.simulate('change', mockEvent);
     setTimeout(() => {
-      expect(component.find('textarea').prop('value')).toEqual(mockValue);
+      expect(component.prop('value')).toEqual(mockValue);
     }, 100);
   });
 });

--- a/lib/components/Textarea/Textarea.test.js
+++ b/lib/components/Textarea/Textarea.test.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Textarea from './index';
+
+const mockValue = 'mockValue';
+const mockEvent = {
+  target: {
+    value: mockValue,
+  },
+};
+const mockChangeHandler = jest.fn();
+
+describe('Textarea', () => {
+  it('renders with type successfully', () => {
+    const onChangeHandler = jest.fn();
+    const component = shallow(<Textarea name="test" onChange={onChangeHandler} />);
+    expect(component.length).toBe(1);
+    expect(component.find('.slds-form-element').length).toBe(1);
+    expect(component.find('.validation-error').length).toBe(0);
+  });
+
+  it('renders field length successfully', () => {
+    const wrapper = shallow(<Textarea name="test" length="huge" />);
+    expect(wrapper.find('textarea').length).toBe(1);
+    expect(wrapper.find('.input--huge').length).toBe(1);
+  });
+
+  it('renders validation state successfully', () => {
+    const wrapper = shallow(<Textarea name="test" state="error" />);
+    expect(wrapper.find('textarea').length).toBe(1);
+    expect(wrapper.find('.validation-error').length).toBe(1);
+  });
+
+  it('renders with rows successfully', () => {
+    const component = shallow(<Textarea name="test" />);
+    expect(component.find('textarea').prop('rows')).toEqual(5);
+
+    const componentWithRows = shallow(<Textarea name="test" rows={10} />);
+    expect(componentWithRows.find('textarea').prop('rows')).toEqual(10);
+  });
+
+  it('renders with textarea readonly', () => {
+    const component = shallow(<Textarea name="test" isReadOnly />);
+    expect(component.find('textarea').prop('readOnly')).toBe(true);
+  });
+
+  it('renders with textarea disabled', () => {
+    const component = shallow(<Textarea name="test" isDisabled />);
+    expect(component.find('textarea').prop('disabled')).toBe(true);
+  });
+
+  it('renders textarea with placeholder', () => {
+    const component = shallow(<Textarea placeholder="test placeholder" />);
+    expect(component.find('textarea').prop('placeholder')).toEqual('test placeholder');
+  });
+
+  it('renders class names with className props', () => {
+    const mockClass = 'test-class';
+    const component = shallow(<Textarea className={mockClass} />);
+    expect(component.find('textarea').hasClass(mockClass)).toEqual(true);
+  });
+
+  it('onValueChange handler can be invoked', () => {
+    const component = shallow(<Textarea name="test" onValueChange={mockChangeHandler} />);
+    component.find('textarea').simulate('change', mockEvent);
+    setTimeout(() => {
+      expect(mockChangeHandler).toBeCalledWith(event);
+    }, 0);
+  });
+
+  it('onValueChange handler can be invoked with a state change', () => {
+    const component = shallow(<Textarea name="test" onValueChange={mockChangeHandler} />);
+    component.setState({ value: mockValue });
+    setTimeout(() => {
+      expect(mockChangeHandler).toBeCalledWith(event);
+    }, 0);
+  });
+
+  it('onChange handler not to be called if no change happens.', () => {
+    const component = shallow(<Textarea name="test" value={mockValue} onValueChange={mockChangeHandler} />);
+    expect(component.find('textarea').prop('value')).toEqual(mockValue);
+    component.find('textarea').simulate('change', mockEvent);
+    setTimeout(() => {
+      expect(mockChangeHandler).not.toBeCalledWith(mockEvent);
+    }, 0);
+  });
+
+  it('componentDidUpdate gets called with onValueChange', () => {
+    const oldValue = 'oldValue';
+    const component = shallow(<Textarea name="test" value={oldValue} onValueChange={mockChangeHandler} />);
+    expect(component.find('textarea').prop('value')).toEqual(oldValue);
+    component.setState({ value: mockValue });
+    setTimeout(() => {
+      expect(component.find('textarea').prop('value')).toEqual(mockValue);
+      expect(mockChangeHandler).toBeCalledWith(mockEvent);
+    }, 0);
+  });
+
+  it('componentDidUpdate does not get called with onValueChange but no value change', () => {
+    const component = shallow(<Textarea name="test" value={mockValue} onValueChange={mockChangeHandler} />);
+    expect(component.find('textarea').prop('value')).toEqual(mockValue);
+    component.setState({ value: mockValue });
+    setTimeout(() => {
+      expect(component.find('textarea').prop('value')).toEqual(mockValue);
+      expect(mockChangeHandler).not.toBeCalledWith(mockEvent);
+    }, 0);
+  });
+
+  it('field value matches input value', () => {
+    const component = shallow(<Textarea name="test" onValueChange={mockChangeHandler} />);
+    expect(component.find('textarea').text()).toEqual('');
+    component.find('textarea').simulate('change', mockEvent);
+    setTimeout(() => {
+      expect(component.find('textarea').prop('value')).toEqual(mockValue);
+    }, 100);
+  });
+});

--- a/stories/TextareaStories.js
+++ b/stories/TextareaStories.js
@@ -6,11 +6,11 @@ import { text, boolean } from '@storybook/addon-knobs';
 
 import { Textarea } from './../lib';
 
-const onValueChange = (val) => {
+const onValueChange = (event) => {
   /**
    * use the callback return val
    */
-  console.log(val); // eslint-disable-line
+  console.log(event.target.value); // eslint-disable-line
 };
 
 storiesOf('Textarea', module)
@@ -68,23 +68,9 @@ storiesOf('Textarea', module)
     )),
   )
   .add(
-    'w/ Error',
-    withInfo('Textarea control with error message')(() => (
-      <Textarea
-        placeholder="Placeholder Text"
-        state="error"
-        required
-        error="This field is required"
-      />
-    )),
-  )
-  .add(
     'Controlled with knobs',
     withInfo('Textarea controlled with knobs')(() => (
       <Textarea
-        label={text('label', 'Textarea Label')}
-        error={text('error')}
-        required={boolean('required')}
         value={text('value')}
         placeholder={text('placeholder')}
         disabled={boolean('disabled')}

--- a/stories/TextareaStories.js
+++ b/stories/TextareaStories.js
@@ -3,38 +3,94 @@ import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
 import { text, boolean } from '@storybook/addon-knobs';
+
 import { Textarea } from './../lib';
 
+const onValueChange = (val) => {
+  /**
+   * use the callback return val
+   */
+  console.log(val); // eslint-disable-line
+};
+
 storiesOf('Textarea', module)
-  .add('Controlled with knobs', withInfo('Textarea controlled with knobs')(() => (
-    <Textarea
-      label={ text('label', 'Textarea Label') }
-      error={ text('error') }
-      required={ boolean('required') }
-      value={ text('value') }
-      placeholder={ text('placeholder') }
-      disabled={ boolean('disabled') }
-      readOnly={ boolean('readOnly') }
-      onChange={ action('change') }
-      onBlur={ action('blur') }
-    />
-  )))
-  .add('Default', withInfo('Default Textarea control')(() => (
-    <Textarea label='Textarea Label' placeholder='Placeholder Text' />
-  )))
-  .add('Required', withInfo('Textarea control with required attribute')(() => (
-    <Textarea label='Textarea Label' placeholder='Placeholder Text' required />
-  )))
-  .add('Error', withInfo('Textarea control with error message')(() => (
-    <Textarea label='Textarea Label' placeholder='Placeholder Text' required error='This field is required' />
-  )))
-  .add('Disabled', withInfo('Textarea control with disabled status')(() => (
-    <Textarea label='Textarea Label' placeholder='Placeholder Text' disabled />
-  )))
-  .add('Read only', withInfo('Textarea control with readOnly status')(() => (
-    <Textarea label='Textarea Label' value='Read Only' readOnly />
-  )))
-  .add('Read only (HTML)', withInfo('Textarea control with readOnly status (passsed to HTML <textarea> element)')(() => (
-    <Textarea label='Textarea Label' value='Read Only' htmlReadOnly />
-  )))
-;
+  .add(
+    'Default Textarea',
+    withInfo('The default textarea will render with 5 rows')(() => (
+      <Textarea
+        placeholder="default textarea"
+        onValueChange={onValueChange}
+        name="comments"
+      />
+    )),
+  )
+  .add(
+    'Disabled / ReadOnly',
+    withInfo(
+      'Textarea can be disabled (*isDisabled*) or marked as readOnly (*isReadOnly*).',
+    )(() => (
+      <div>
+        <Textarea
+          value="disabled"
+          isDisabled
+          onValueChange={action('textarea-disabled-onchange')}
+        />
+        <br />
+        <br />
+        <Textarea
+          value="readonly"
+          isReadOnly
+          onValueChange={action('textarea-readonly-onchange')}
+        />
+      </div>
+    )),
+  )
+  .add(
+    'w/ Custom Rows',
+    withInfo(
+      'Textarea can have as many rows as you want by passing *rows* .',
+    )(() => (
+      <Textarea
+        placeholder="this textarea should have 10 rows"
+        rows={10}
+        onValueChange={action('textarea-rows-onchange')}
+      />
+    )),
+  )
+  .add(
+    'w/ large text',
+    withInfo('Textarea can be rendered with huge text')(() => (
+      <Textarea
+        placeholder="this textarea should have HUGE text"
+        className="input--huge"
+        onChange={action('textarea-rows-onchange')}
+      />
+    )),
+  )
+  .add(
+    'w/ Error',
+    withInfo('Textarea control with error message')(() => (
+      <Textarea
+        placeholder="Placeholder Text"
+        state="error"
+        required
+        error="This field is required"
+      />
+    )),
+  )
+  .add(
+    'Controlled with knobs',
+    withInfo('Textarea controlled with knobs')(() => (
+      <Textarea
+        label={text('label', 'Textarea Label')}
+        error={text('error')}
+        required={boolean('required')}
+        value={text('value')}
+        placeholder={text('placeholder')}
+        disabled={boolean('disabled')}
+        readOnly={boolean('readOnly')}
+        onChange={action('change')}
+        onBlur={action('blur')}
+      />
+    )),
+  );


### PR DESCRIPTION
- Most part uses the *-predix Textarea component, in addition to lightning stuffs.
- Refactored, way the callback being called in render function. Now that, it uses setState(stateChange[, callback]) pattern, and one less of this.onChange
- Supports 'error' prop to display required field message.
- Supports 'id' prop if supplied, Or else fallback to uuid generated id.
- All tests are in green :)