### PR TITLE
UI-433 Modal (component, test, storybook)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,7 +37,8 @@
     "no-return-assign": "off",
     "no-mixed-operators": "off",
     "no-trailing-spaces": ["error", { "ignoreComments": true }],
-    "lines-between-class-members": ["error", "always"]
+    "lines-between-class-members": ["error", "always"],
+    "sort-keys": ["error"]
   },
   "settings": {
     "import/resolver": {

--- a/lib/components/Modal/Modal.js
+++ b/lib/components/Modal/Modal.js
@@ -1,77 +1,41 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Button } from './../Button';
+import ModalHeader from './ModalHeader';
+import ModalContent from './ModalContent';
+import ModalFooter from './ModalFooter';
 
-export class ModalHeader extends Component {
-  constructor() {
-    super();
+const MODAL_SIZES = ['regular', 'large'];
 
-    this.onClose = this.onClose.bind(this);
-  }
-
-  onClose() {
-    if (this.props.onClose) {
-      this.props.onClose();
-    }
-  }
-
-  render() {
-    const { className, title, tagline, closeButton, ...props } = this.props;
-    delete props.onClose;
-    const hdClassNames = classnames(className, 'slds-modal__header');
-    return (
-      <div className={hdClassNames} {...props}>
-        <h2 className="slds-text-heading--medium">{ title }</h2>
-        {
-          tagline ?
-            <p className="slds-m-top--x-small">{ tagline }</p> :
-            null
-        }
-        {
-          closeButton ?
-            <Button
-              className="slds-modal__close"
-              icon="close"
-              iconSize="large"
-              alt="Close"
-              inverse
-              onClick={this.onClose}
-            /> :
-            null
-        }
-      </div>
-    );
-  }
-}
-
-ModalHeader.propTypes = {
-  title: PropTypes.string,
-  tagline: PropTypes.string,
-  onClose: PropTypes.func,
+const propTypes = {
   className: PropTypes.string,
-  closeButton: PropTypes.bool,
+  size: PropTypes.oneOf(MODAL_SIZES),
+  opened: PropTypes.bool,
+  onHide: PropTypes.func,
+  containerStyle: PropTypes.object,
+  children: PropTypes.node,
+};
+
+const defaultProps = {
+  size: 'regular',
+  opened: false,
+  onHide: null,
+  containerStyle: {},
 };
 
 class Modal extends Component {
-  constructor() {
-    super();
-
-    this.renderChildComponent = this.renderChildComponent.bind(this);
-  }
-
-  hide() {
+  hide = () => {
     if (this.props.onHide) {
       this.props.onHide();
     }
-  }
+  };
 
-  renderChildComponent(comp) {
+  renderChildComponent = comp => {
     if (comp.type === ModalHeader) {
-      return React.cloneElement(comp, { onClose: this.hide.bind(this) });
+      return React.cloneElement(comp, { onClose: this.hide });
     }
     return comp;
-  }
+  };
 
   render() {
     const { className, opened, children, size, containerStyle, ...props } = this.props;
@@ -87,7 +51,7 @@ class Modal extends Component {
       <div>
         <div className={modalClassNames} aria-hidden={!opened} role="dialog" {...props}>
           <div className="slds-modal__container" style={containerStyle}>
-            { React.Children.map(children, this.renderChildComponent) }
+            {React.Children.map(children, this.renderChildComponent)}
           </div>
         </div>
         <div className={backdropClassNames} />
@@ -96,52 +60,13 @@ class Modal extends Component {
   }
 }
 
-const MODAL_SIZES = ['large'];
+Modal.propTypes = propTypes;
+Modal.defaultProps = defaultProps;
 
-Modal.propTypes = {
-  className: PropTypes.string,
-  size: PropTypes.oneOf(MODAL_SIZES),
-  opened: PropTypes.bool,
-  onHide: PropTypes.func,
-  children: PropTypes.node,
-  /* eslint-disable react/forbid-prop-types */
-  containerStyle: PropTypes.object,
-};
-
-
-export const ModalContent = ({ className, children, ...props }) => {
-  const ctClassNames = classnames(className, 'slds-modal__content');
-  return (
-    <div className={ctClassNames} {...props}>{ children }</div>
-  );
-};
-
-ModalContent.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node,
-};
-
-
-export const ModalFooter = ({ className, directional, children, ...props }) => {
-  const ftClassNames = classnames(
-    className,
-    'slds-modal__footer',
-    { 'slds-modal__footer--directional': directional },
-  );
-  return (
-    <div className={ftClassNames} {...props}>{ children }</div>
-  );
-};
-
-ModalFooter.propTypes = {
-  className: PropTypes.string,
-  directional: PropTypes.bool,
-  children: PropTypes.node,
-};
-
-
+Modal.validSizes = MODAL_SIZES;
 Modal.Header = ModalHeader;
 Modal.Content = ModalContent;
 Modal.Footer = ModalFooter;
 
+export { ModalHeader, ModalContent, ModalFooter };
 export default Modal;

--- a/lib/components/Modal/Modal.js
+++ b/lib/components/Modal/Modal.js
@@ -44,17 +44,17 @@ class Modal extends Component {
   render() {
     const { className, isOpened, children, size, ...props } = this.props;
     delete props.onHide;
-    const modalClassNames = classnames(className, 'slds-modal', {
+    const modalClassNames = classnames('Modal', className, 'slds-modal', {
       'slds-fade-in-open': isOpened,
       'slds-modal--large': size === 'large',
     });
-    const backdropClassNames = classnames(className, 'slds-modal-backdrop', {
+    const backdropClassNames = classnames('Modal__backdrop', className, 'slds-modal-backdrop', {
       'slds-modal-backdrop--open': isOpened,
     });
     return (
       <div>
-        <div className={`${modalClassNames} Modal`} aria-hidden={!isOpened} role="dialog" {...props}>
-          <div className="slds-modal__container Modal__container">
+        <div className={modalClassNames} aria-hidden={!isOpened} role="dialog" {...props}>
+          <div className="Modal__container slds-modal__container">
             {React.Children.map(children, this.renderChildComponent)}
           </div>
         </div>

--- a/lib/components/Modal/Modal.js
+++ b/lib/components/Modal/Modal.js
@@ -16,14 +16,12 @@ const propTypes = {
    * Regular - width: 50%; max-width: 40rem; min-width: 20rem;
    * Large - width: 90%;
    */
-  containerStyle: PropTypes.object,
   isOpened: PropTypes.bool,
   onHide: PropTypes.func,
   size: PropTypes.oneOf(MODAL_SIZES),
 };
 
 const defaultProps = {
-  containerStyle: {},
   isOpened: false,
   onHide: null,
   size: 'regular',
@@ -44,7 +42,7 @@ class Modal extends Component {
   };
 
   render() {
-    const { className, isOpened, children, size, containerStyle, ...props } = this.props;
+    const { className, isOpened, children, size, ...props } = this.props;
     delete props.onHide;
     const modalClassNames = classnames(className, 'slds-modal', {
       'slds-fade-in-open': isOpened,
@@ -55,8 +53,8 @@ class Modal extends Component {
     });
     return (
       <div>
-        <div className={modalClassNames} aria-hidden={!isOpened} role="dialog" {...props}>
-          <div className="slds-modal__container" style={containerStyle}>
+        <div className={`${modalClassNames} Modal`} aria-hidden={!isOpened} role="dialog" {...props}>
+          <div className="slds-modal__container Modal__container">
             {React.Children.map(children, this.renderChildComponent)}
           </div>
         </div>

--- a/lib/components/Modal/Modal.js
+++ b/lib/components/Modal/Modal.js
@@ -8,6 +8,7 @@ import ModalFooter from './ModalFooter';
 const MODAL_SIZES = ['regular', 'large'];
 
 const propTypes = {
+  children: PropTypes.node,
   className: PropTypes.string,
   /**
    * Size of the Modal
@@ -15,18 +16,17 @@ const propTypes = {
    * Regular - width: 50%; max-width: 40rem; min-width: 20rem;
    * Large - width: 90%;
    */
-  size: PropTypes.oneOf(MODAL_SIZES),
-  opened: PropTypes.bool,
-  onHide: PropTypes.func,
   containerStyle: PropTypes.object,
-  children: PropTypes.node,
+  isOpened: PropTypes.bool,
+  onHide: PropTypes.func,
+  size: PropTypes.oneOf(MODAL_SIZES),
 };
 
 const defaultProps = {
-  size: 'regular',
-  opened: false,
-  onHide: null,
   containerStyle: {},
+  isOpened: false,
+  onHide: null,
+  size: 'regular',
 };
 
 class Modal extends Component {
@@ -44,18 +44,18 @@ class Modal extends Component {
   };
 
   render() {
-    const { className, opened, children, size, containerStyle, ...props } = this.props;
+    const { className, isOpened, children, size, containerStyle, ...props } = this.props;
     delete props.onHide;
     const modalClassNames = classnames(className, 'slds-modal', {
-      'slds-fade-in-open': opened,
+      'slds-fade-in-open': isOpened,
       'slds-modal--large': size === 'large',
     });
     const backdropClassNames = classnames(className, 'slds-modal-backdrop', {
-      'slds-modal-backdrop--open': opened,
+      'slds-modal-backdrop--open': isOpened,
     });
     return (
       <div>
-        <div className={modalClassNames} aria-hidden={!opened} role="dialog" {...props}>
+        <div className={modalClassNames} aria-hidden={!isOpened} role="dialog" {...props}>
           <div className="slds-modal__container" style={containerStyle}>
             {React.Children.map(children, this.renderChildComponent)}
           </div>
@@ -74,5 +74,4 @@ Modal.Header = ModalHeader;
 Modal.Content = ModalContent;
 Modal.Footer = ModalFooter;
 
-export { ModalHeader, ModalContent, ModalFooter };
 export default Modal;

--- a/lib/components/Modal/Modal.js
+++ b/lib/components/Modal/Modal.js
@@ -9,6 +9,12 @@ const MODAL_SIZES = ['regular', 'large'];
 
 const propTypes = {
   className: PropTypes.string,
+  /**
+   * Size of the Modal
+   * 
+   * Regular - width: 50%; max-width: 40rem; min-width: 20rem;
+   * Large - width: 90%;
+   */
   size: PropTypes.oneOf(MODAL_SIZES),
   opened: PropTypes.bool,
   onHide: PropTypes.func,

--- a/lib/components/Modal/Modal.test.js
+++ b/lib/components/Modal/Modal.test.js
@@ -36,12 +36,6 @@ describe('Modal', () => {
     expect(wrapper.childAt(0).hasClass('slds-fade-in-open')).toBe(true);
   });
 
-  it('should render container style', () => {
-    const style = { backgroundColor: 'grey' };
-    const wrapper = shallow(<Modal containerStyle={style} />);
-    expect(wrapper.find('.slds-modal__container').prop('style')).toEqual(style);
-  });
-
   it('simulates onHide hook', () => {
     const onModalHide = jest.fn();
     const wrapper = shallow(<Modal onHide={onModalHide} />);

--- a/lib/components/Modal/Modal.test.js
+++ b/lib/components/Modal/Modal.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { Modal } from './../Modal';
+
+describe('Modal', () => {
+  it('should render modal with default values', () => {
+    const wrapper = shallow(<Modal />);
+    expect(wrapper.childAt(0).hasClass('slds-modal--large')).toBe(false);
+    expect(wrapper.childAt(0).hasClass('slds-fade-in-open')).toBe(false);
+  });
+
+  it('should render modal with children', () => {
+    const children = <span>Test</span>;
+    const wrapper = shallow(<Modal>{children}</Modal>);
+    expect(wrapper.contains(children)).toBe(true);
+  });
+
+  it('should render modal with specific className', () => {
+    const className = 'test';
+    const wrapper = shallow(<Modal className={className} />);
+    expect(wrapper.childAt(0).hasClass(className)).toBe(true);
+  });
+
+  it('should render modal with other props', () => {
+    const wrapper = shallow(<Modal otherProp={9} />);
+    expect(wrapper.childAt(0).prop('otherProp')).toBe(9);
+  });
+
+  it('should render large size', () => {
+    const wrapper = shallow(<Modal size="large" />);
+    expect(wrapper.childAt(0).hasClass('slds-modal--large')).toBe(true);
+  });
+
+  it('should render opened modal', () => {
+    const wrapper = shallow(<Modal opened />);
+    expect(wrapper.childAt(0).hasClass('slds-fade-in-open')).toBe(true);
+  });
+
+  it('should render container style', () => {
+    const style = { backgroundColor: 'grey' };
+    const wrapper = shallow(<Modal containerStyle={style} />);
+    expect(wrapper.find('.slds-modal__container').prop('style')).toEqual(style);
+  });
+
+  it('simulates onHide hook', () => {
+    const onModalHide = sinon.spy();
+    const wrapper = shallow(<Modal onHide={onModalHide} />);
+    wrapper.instance().hide();
+    expect(onModalHide.calledOnce).toBe(true);
+  });
+});

--- a/lib/components/Modal/Modal.test.js
+++ b/lib/components/Modal/Modal.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Modal } from './../Modal';
+import Modal from './Modal';
 
 describe('Modal', () => {
   it('should render modal with default values', () => {

--- a/lib/components/Modal/Modal.test.js
+++ b/lib/components/Modal/Modal.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import sinon from 'sinon';
 import { Modal } from './../Modal';
 
 describe('Modal', () => {
@@ -33,7 +32,7 @@ describe('Modal', () => {
   });
 
   it('should render opened modal', () => {
-    const wrapper = shallow(<Modal opened />);
+    const wrapper = shallow(<Modal isOpened />);
     expect(wrapper.childAt(0).hasClass('slds-fade-in-open')).toBe(true);
   });
 
@@ -44,9 +43,9 @@ describe('Modal', () => {
   });
 
   it('simulates onHide hook', () => {
-    const onModalHide = sinon.spy();
+    const onModalHide = jest.fn();
     const wrapper = shallow(<Modal onHide={onModalHide} />);
     wrapper.instance().hide();
-    expect(onModalHide.calledOnce).toBe(true);
+    expect(onModalHide).toHaveBeenCalled();
   });
 });

--- a/lib/components/Modal/ModalContent.js
+++ b/lib/components/Modal/ModalContent.js
@@ -10,9 +10,9 @@ const propTypes = {
 const defaultProps = {};
 
 const ModalContent = ({ className, children, ...props }) => {
-  const ctClassNames = classnames(className, 'slds-modal__content');
+  const ctClassNames = classnames('ModalContent', className, 'slds-modal__content');
   return (
-    <div className={`${ctClassNames} ModalContent`} {...props}>
+    <div className={ctClassNames} {...props}>
       {children}
     </div>
   );

--- a/lib/components/Modal/ModalContent.js
+++ b/lib/components/Modal/ModalContent.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+const defaultTypes = {};
+
+const ModalContent = ({ className, children, ...props }) => {
+  const ctClassNames = classnames(className, 'slds-modal__content');
+  return (
+    <div className={ctClassNames} {...props}>
+      {children}
+    </div>
+  );
+};
+
+ModalContent.propTypes = propTypes;
+ModalContent.defaultTypes = defaultTypes;
+
+export default ModalContent;

--- a/lib/components/Modal/ModalContent.js
+++ b/lib/components/Modal/ModalContent.js
@@ -12,7 +12,7 @@ const defaultProps = {};
 const ModalContent = ({ className, children, ...props }) => {
   const ctClassNames = classnames(className, 'slds-modal__content');
   return (
-    <div className={ctClassNames} {...props}>
+    <div className={`${ctClassNames} ModalContent`} {...props}>
       {children}
     </div>
   );

--- a/lib/components/Modal/ModalContent.js
+++ b/lib/components/Modal/ModalContent.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 const propTypes = {
-  className: PropTypes.string,
   children: PropTypes.node,
+  className: PropTypes.string,
 };
 
 const defaultProps = {};

--- a/lib/components/Modal/ModalContent.js
+++ b/lib/components/Modal/ModalContent.js
@@ -7,7 +7,7 @@ const propTypes = {
   children: PropTypes.node,
 };
 
-const defaultTypes = {};
+const defaultProps = {};
 
 const ModalContent = ({ className, children, ...props }) => {
   const ctClassNames = classnames(className, 'slds-modal__content');
@@ -19,6 +19,6 @@ const ModalContent = ({ className, children, ...props }) => {
 };
 
 ModalContent.propTypes = propTypes;
-ModalContent.defaultTypes = defaultTypes;
+ModalContent.defaultProps = defaultProps;
 
 export default ModalContent;

--- a/lib/components/Modal/ModalContent.test.js
+++ b/lib/components/Modal/ModalContent.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ModalContent } from './../Modal';
+import ModalContent from './ModalContent';
 
 describe('ModalContent', () => {
   it('should render modal content with children', () => {

--- a/lib/components/Modal/ModalContent.test.js
+++ b/lib/components/Modal/ModalContent.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ModalContent } from './../Modal';
+
+describe('ModalContent', () => {
+  it('should render modal content with children', () => {
+    const children = <span>Test</span>;
+    const wrapper = shallow(<ModalContent>{children}</ModalContent>);
+    expect(wrapper.contains(children)).toBe(true);
+  });
+
+  it('should render modal content with specific className', () => {
+    const className = 'test';
+    const wrapper = shallow(<ModalContent className={className} />);
+    expect(wrapper.hasClass(className)).toBe(true);
+  });
+
+  it('should render modal content with other props', () => {
+    const wrapper = shallow(<ModalContent otherProp={9} />);
+    expect(wrapper.prop('otherProp')).toBe(9);
+  });
+});

--- a/lib/components/Modal/ModalFooter.js
+++ b/lib/components/Modal/ModalFooter.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 const propTypes = {
+  children: PropTypes.node,
   className: PropTypes.string,
   /**
    * pull the first element of footer to the left
    */
   directional: PropTypes.bool,
-  children: PropTypes.node,
 };
 
 const defaultProps = {

--- a/lib/components/Modal/ModalFooter.js
+++ b/lib/components/Modal/ModalFooter.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const propTypes = {
+  className: PropTypes.string,
+  directional: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+const defaultTypes = {
+  directional: false,
+};
+
+const ModalFooter = ({ className, directional, children, ...props }) => {
+  const ftClassNames = classnames(className, 'slds-modal__footer', {
+    'slds-modal__footer--directional': directional,
+  });
+  return (
+    <div className={ftClassNames} {...props}>
+      {children}
+    </div>
+  );
+};
+
+ModalFooter.propTypes = propTypes;
+ModalFooter.defaultTypes = defaultTypes;
+
+export default ModalFooter;

--- a/lib/components/Modal/ModalFooter.js
+++ b/lib/components/Modal/ModalFooter.js
@@ -20,7 +20,7 @@ const ModalFooter = ({ className, directional, children, ...props }) => {
     'slds-modal__footer--directional': directional,
   });
   return (
-    <div className={ftClassNames} {...props}>
+    <div className={`${ftClassNames} ModalFooter`} {...props}>
       {children}
     </div>
   );

--- a/lib/components/Modal/ModalFooter.js
+++ b/lib/components/Modal/ModalFooter.js
@@ -16,11 +16,11 @@ const defaultProps = {
 };
 
 const ModalFooter = ({ className, directional, children, ...props }) => {
-  const ftClassNames = classnames(className, 'slds-modal__footer', {
+  const ftClassNames = classnames('ModalFooter', className, 'slds-modal__footer', {
     'slds-modal__footer--directional': directional,
   });
   return (
-    <div className={`${ftClassNames} ModalFooter`} {...props}>
+    <div className={ftClassNames} {...props}>
       {children}
     </div>
   );

--- a/lib/components/Modal/ModalFooter.js
+++ b/lib/components/Modal/ModalFooter.js
@@ -4,11 +4,14 @@ import classnames from 'classnames';
 
 const propTypes = {
   className: PropTypes.string,
+  /**
+   * pull the first element of footer to the left
+   */
   directional: PropTypes.bool,
   children: PropTypes.node,
 };
 
-const defaultTypes = {
+const defaultProps = {
   directional: false,
 };
 
@@ -24,6 +27,6 @@ const ModalFooter = ({ className, directional, children, ...props }) => {
 };
 
 ModalFooter.propTypes = propTypes;
-ModalFooter.defaultTypes = defaultTypes;
+ModalFooter.defaultProps = defaultProps;
 
 export default ModalFooter;

--- a/lib/components/Modal/ModalFooter.test.js
+++ b/lib/components/Modal/ModalFooter.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ModalFooter } from './../Modal';
+import ModalFooter from './ModalFooter';
 
 describe('ModalFooter', () => {
   it('should render modal footer with default values', () => {

--- a/lib/components/Modal/ModalFooter.test.js
+++ b/lib/components/Modal/ModalFooter.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ModalFooter } from './../Modal';
+
+describe('ModalFooter', () => {
+  it('should render modal footer with default values', () => {
+    const wrapper = shallow(<ModalFooter />);
+    expect(wrapper.hasClass('slds-modal__footer--directional')).toBe(false);
+  });
+
+  it('should render modal footer with children', () => {
+    const children = <span>Test</span>;
+    const wrapper = shallow(<ModalFooter>{children}</ModalFooter>);
+    expect(wrapper.contains(children)).toBe(true);
+  });
+
+  it('should render modal footer with specific className', () => {
+    const className = 'test';
+    const wrapper = shallow(<ModalFooter className={className} />);
+    expect(wrapper.hasClass(className)).toBe(true);
+  });
+
+  it('should render modal footer with other props', () => {
+    const wrapper = shallow(<ModalFooter otherProp={9} />);
+    expect(wrapper.prop('otherProp')).toBe(9);
+  });
+
+  it('should render modal footer with directional alignment', () => {
+    const wrapper = shallow(<ModalFooter directional />);
+    expect(wrapper.hasClass('slds-modal__footer--directional')).toBe(true);
+  });
+});

--- a/lib/components/Modal/ModalHeader.js
+++ b/lib/components/Modal/ModalHeader.js
@@ -32,15 +32,15 @@ class ModalHeader extends Component {
   render() {
     const { className, title, tagline, closeButton, ...props } = this.props;
     delete props.onClose;
-    const hdClassNames = classnames(className, 'slds-modal__header');
+    const hdClassNames = classnames('ModalHeader', className, 'slds-modal__header');
     return (
-      <div className={`${hdClassNames} ModalHeader`} {...props}>
-        <h2 className="slds-text-heading--medium ModalHeader__title">{title}</h2>
-        {tagline && <p className="slds-m-top--x-small ModalHeader__tagline                                                                           ">{tagline}</p>}
+      <div className={hdClassNames} {...props}>
+        <h2 className="ModalHeader__title slds-text-heading--medium">{title}</h2>
+        {tagline && <p className="ModalHeader__tagline slds-m-top--x-small                                                                            ">{tagline}</p>}
         {closeButton && (
           <Button
             type="icon-inverse"
-            className="slds-modal__close ModalHeader__close"
+            className="ModalHeader__close slds-modal__close"
             alt="Close"
             inverse
             onClick={this.onClose}

--- a/lib/components/Modal/ModalHeader.js
+++ b/lib/components/Modal/ModalHeader.js
@@ -9,6 +9,9 @@ const propTypes = {
   tagline: PropTypes.string,
   onClose: PropTypes.func,
   className: PropTypes.string,
+  /**
+   * Show close icon button at top right
+   */
   closeButton: PropTypes.bool,
 };
 

--- a/lib/components/Modal/ModalHeader.js
+++ b/lib/components/Modal/ModalHeader.js
@@ -5,21 +5,21 @@ import { Button } from './../Button';
 import Icon from './../Icon';
 
 const propTypes = {
-  title: PropTypes.string,
-  tagline: PropTypes.string,
-  onClose: PropTypes.func,
   className: PropTypes.string,
   /**
    * Show close icon button at top right
    */
   closeButton: PropTypes.bool,
+  onClose: PropTypes.func,
+  tagline: PropTypes.string,
+  title: PropTypes.string,
 };
 
 const defaultProps = {
-  title: '',
-  tagline: '',
-  onClose: null,
   closeButton: true,
+  onClose: null,
+  tagline: '',
+  title: '',
 };
 
 class ModalHeader extends Component {

--- a/lib/components/Modal/ModalHeader.js
+++ b/lib/components/Modal/ModalHeader.js
@@ -34,13 +34,13 @@ class ModalHeader extends Component {
     delete props.onClose;
     const hdClassNames = classnames(className, 'slds-modal__header');
     return (
-      <div className={hdClassNames} {...props}>
-        <h2 className="slds-text-heading--medium">{title}</h2>
-        {tagline && <p className="slds-m-top--x-small">{tagline}</p>}
+      <div className={`${hdClassNames} ModalHeader`} {...props}>
+        <h2 className="slds-text-heading--medium ModalHeader__title">{title}</h2>
+        {tagline && <p className="slds-m-top--x-small ModalHeader__tagline                                                                           ">{tagline}</p>}
         {closeButton && (
           <Button
             type="icon-inverse"
-            className="slds-modal__close"
+            className="slds-modal__close ModalHeader__close"
             alt="Close"
             inverse
             onClick={this.onClose}

--- a/lib/components/Modal/ModalHeader.js
+++ b/lib/components/Modal/ModalHeader.js
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { Button } from './../Button';
+import Icon from './../Icon';
+
+const propTypes = {
+  title: PropTypes.string,
+  tagline: PropTypes.string,
+  onClose: PropTypes.func,
+  className: PropTypes.string,
+  closeButton: PropTypes.bool,
+};
+
+const defaultProps = {
+  title: '',
+  tagline: '',
+  onClose: null,
+  closeButton: true,
+};
+
+class ModalHeader extends Component {
+  onClose = () => {
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
+  };
+
+  render() {
+    const { className, title, tagline, closeButton, ...props } = this.props;
+    delete props.onClose;
+    const hdClassNames = classnames(className, 'slds-modal__header');
+    return (
+      <div className={hdClassNames} {...props}>
+        <h2 className="slds-text-heading--medium">{title}</h2>
+        {tagline && <p className="slds-m-top--x-small">{tagline}</p>}
+        {closeButton && (
+          <Button
+            type="icon-inverse"
+            className="slds-modal__close"
+            alt="Close"
+            inverse
+            onClick={this.onClose}
+          >
+            <Icon category="utility" icon="close" size="large" />
+          </Button>
+        )}
+      </div>
+    );
+  }
+}
+
+ModalHeader.propTypes = propTypes;
+ModalHeader.defaultProps = defaultProps;
+
+export default ModalHeader;

--- a/lib/components/Modal/ModalHeader.test.js
+++ b/lib/components/Modal/ModalHeader.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ModalHeader } from './../Modal';
+import ModalHeader from './ModalHeader';
 
 describe('ModalHeader', () => {
   it('should render modal header with default values', () => {

--- a/lib/components/Modal/ModalHeader.test.js
+++ b/lib/components/Modal/ModalHeader.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { ModalHeader } from './../Modal';
+
+describe('ModalHeader', () => {
+  it('should render modal header with default values', () => {
+    const wrapper = shallow(<ModalHeader />);
+    expect(wrapper.find('.slds-modal__close').exists()).toBe(true);
+  });
+
+  it('should render modal header with no children', () => {
+    const children = <span>Test</span>;
+    const wrapper = shallow(<ModalHeader>{children}</ModalHeader>);
+    expect(wrapper.contains(children)).toBe(false);
+  });
+
+  it('should render modal header with specific className', () => {
+    const className = 'test';
+    const wrapper = shallow(<ModalHeader className={className} />);
+    expect(wrapper.hasClass(className)).toBe(true);
+  });
+
+  it('should render modal header with other props', () => {
+    const wrapper = shallow(<ModalHeader otherProp={9} />);
+    expect(wrapper.prop('otherProp')).toBe(9);
+  });
+
+  it('should render modal header with title', () => {
+    const title = 'Header Title';
+    const wrapper = shallow(<ModalHeader title={title} />);
+    expect(wrapper.find('.slds-text-heading--medium').text()).toBe(title);
+  });
+
+  it('should render modal header with title', () => {
+    const title = 'Header Title';
+    const wrapper = shallow(<ModalHeader title={title} />);
+    expect(wrapper.find('.slds-text-heading--medium').text()).toBe(title);
+  });
+
+  it('should render modal header with tagline', () => {
+    const tagline = 'Header TagLine';
+    const wrapper = shallow(<ModalHeader tagline={tagline} />);
+    expect(wrapper.find('.slds-m-top--x-small').text()).toBe(tagline);
+  });
+
+  it('should render modal header with no close button', () => {
+    const wrapper = shallow(<ModalHeader closeButton={false} />);
+    expect(wrapper.find('.slds-modal__close').exists()).toBe(false);
+  });
+
+  it('simulates click close button', () => {
+    const onModalHide = sinon.spy();
+    const wrapper = shallow(<ModalHeader onClose={onModalHide} />);
+    wrapper.find('.slds-modal__close').simulate('click');
+    expect(onModalHide.calledOnce).toBe(true);
+  });
+});

--- a/lib/components/Modal/ModalHeader.test.js
+++ b/lib/components/Modal/ModalHeader.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import sinon from 'sinon';
 import { ModalHeader } from './../Modal';
 
 describe('ModalHeader', () => {
@@ -50,9 +49,9 @@ describe('ModalHeader', () => {
   });
 
   it('simulates click close button', () => {
-    const onModalHide = sinon.spy();
+    const onModalHide = jest.fn();
     const wrapper = shallow(<ModalHeader onClose={onModalHide} />);
     wrapper.find('.slds-modal__close').simulate('click');
-    expect(onModalHide.calledOnce).toBe(true);
+    expect(onModalHide).toHaveBeenCalled();
   });
 });

--- a/lib/components/Modal/index.js
+++ b/lib/components/Modal/index.js
@@ -1,3 +1,6 @@
-import Modal, { ModalHeader, ModalContent, ModalFooter } from './Modal';
+import Modal from './Modal';
+import ModalHeader from './ModalHeader';
+import ModalContent from './ModalContent';
+import ModalFooter from './ModalFooter';
 
 export { Modal, ModalHeader, ModalContent, ModalFooter };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,7 +3492,7 @@
     },
     "debounce": {
       "version": "1.1.0",
-      "resolved": "https://npm.servicemax.io/debounce/-/debounce-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.1.0.tgz",
       "integrity": "sha512-ZQVKfRVlwRfD150ndzEK8M90ABT+Y/JQKs4Y7U4MXdpuoUkkrr4DwKbVux3YjylA5bUMUj0Nc3pMxPJX6N2QQQ=="
     },
     "debug": {
@@ -5334,6 +5334,15 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
+      }
+    },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
       }
     },
     "forwarded": {
@@ -8498,6 +8507,12 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "keycode": {
       "version": "2.1.9",
       "resolved": "https://npm.servicemax.io/keycode/-/keycode-2.1.9.tgz",
@@ -8708,6 +8723,12 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://npm.servicemax.io/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -8869,6 +8890,12 @@
           "dev": true
         }
       }
+    },
+    "lolex": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -9388,6 +9415,42 @@
       "resolved": "https://npm.servicemax.io/nested-object-assign/-/nested-object-assign-1.0.2.tgz",
       "integrity": "sha512-Ma9vkvU+v0/dPUMNQxu/6Ah2PoU+x52mxkn4FKhofJrzYocSds5eSpgMEdGSjM4IEqkHUqGugioI/+mgq9eBfw==",
       "dev": true
+    },
+    "nise": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.2.tgz",
+      "integrity": "sha512-rvxf+PSZeCKtP0DgmwMmNf1G3I6X1r4WHiP2H88PlIkOkt7mGqufdokjS8caoHBgZzVx0ee/5ytGcGHbZaUw8w==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-dir": {
       "version": "0.1.17",
@@ -13229,6 +13292,12 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "sane": {
       "version": "2.2.0",
       "resolved": "https://npm.servicemax.io/sane/-/sane-2.2.0.tgz",
@@ -13419,6 +13488,32 @@
       "resolved": "https://npm.servicemax.io/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.2.2.tgz",
+      "integrity": "sha512-BEa593xl+IkIc94nKo0O0LauQC/gQy8Gyv4DkzPwF/9DweC5phr1y+42zibCpn9abfkdHxt9r8AhD0R6u9DE/Q==",
+      "dev": true,
+      "requires": {
+        "diff": "3.4.0",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.2",
+        "nise": "1.2.2",
+        "supports-color": "5.1.0",
+        "type-detect": "4.0.7"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -14335,6 +14430,12 @@
         }
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://npm.servicemax.io/text-table/-/text-table-0.2.0.tgz",
@@ -14546,6 +14647,12 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
+      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5336,15 +5336,6 @@
         "mime-types": "2.1.17"
       }
     },
-    "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.3.0"
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://npm.servicemax.io/forwarded/-/forwarded-0.1.2.tgz",
@@ -8507,12 +8498,6 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
-    "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
-      "dev": true
-    },
     "keycode": {
       "version": "2.1.9",
       "resolved": "https://npm.servicemax.io/keycode/-/keycode-2.1.9.tgz",
@@ -8723,12 +8708,6 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://npm.servicemax.io/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -8890,12 +8869,6 @@
           "dev": true
         }
       }
-    },
-    "lolex": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
-      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -9415,42 +9388,6 @@
       "resolved": "https://npm.servicemax.io/nested-object-assign/-/nested-object-assign-1.0.2.tgz",
       "integrity": "sha512-Ma9vkvU+v0/dPUMNQxu/6Ah2PoU+x52mxkn4FKhofJrzYocSds5eSpgMEdGSjM4IEqkHUqGugioI/+mgq9eBfw==",
       "dev": true
-    },
-    "nise": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.2.tgz",
-      "integrity": "sha512-rvxf+PSZeCKtP0DgmwMmNf1G3I6X1r4WHiP2H88PlIkOkt7mGqufdokjS8caoHBgZzVx0ee/5ytGcGHbZaUw8w==",
-      "dev": true,
-      "requires": {
-        "formatio": "1.2.0",
-        "just-extend": "1.1.27",
-        "lolex": "1.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "lolex": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-          "dev": true
-        },
-        "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
-      }
     },
     "node-dir": {
       "version": "0.1.17",
@@ -13292,12 +13229,6 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "dev": true
-    },
     "sane": {
       "version": "2.2.0",
       "resolved": "https://npm.servicemax.io/sane/-/sane-2.2.0.tgz",
@@ -13488,32 +13419,6 @@
       "resolved": "https://npm.servicemax.io/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
-    },
-    "sinon": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.2.2.tgz",
-      "integrity": "sha512-BEa593xl+IkIc94nKo0O0LauQC/gQy8Gyv4DkzPwF/9DweC5phr1y+42zibCpn9abfkdHxt9r8AhD0R6u9DE/Q==",
-      "dev": true,
-      "requires": {
-        "diff": "3.4.0",
-        "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.2",
-        "nise": "1.2.2",
-        "supports-color": "5.1.0",
-        "type-detect": "4.0.7"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
-      }
     },
     "slash": {
       "version": "1.0.0",
@@ -14430,12 +14335,6 @@
         }
       }
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "dev": true
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://npm.servicemax.io/text-table/-/text-table-0.2.0.tgz",
@@ -14647,12 +14546,6 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
-      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
-      "dev": true
     },
     "type-is": {
       "version": "1.6.15",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react-addons-test-utils": "^15.6.2",
     "react-dom": "^15.6.2",
     "react-test-renderer": "^15.6.2",
+    "sinon": "^4.2.2",
     "sonarqube-scanner": "^2.0.2",
     "stylelint": "^8.1.1",
     "stylelint-config-sass-guidelines": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "react-addons-test-utils": "^15.6.2",
     "react-dom": "^15.6.2",
     "react-test-renderer": "^15.6.2",
-    "sinon": "^4.2.2",
     "sonarqube-scanner": "^2.0.2",
     "stylelint": "^8.1.1",
     "stylelint-config-sass-guidelines": "^3.1.0",

--- a/stories/ModalStories.js
+++ b/stories/ModalStories.js
@@ -3,7 +3,17 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
 import { text, select, boolean } from '@storybook/addon-knobs';
-import { Modal, Button, Form, FieldSet, Input, DateInput, Lookup, Picklist, PicklistItem } from './../lib';
+import {
+  Modal,
+  Button,
+  Form,
+  FieldSet,
+  Input,
+  DateInput,
+  Lookup,
+  Picklist,
+  PicklistItem,
+} from './../lib';
 
 const { Header, Content, Footer } = Modal;
 const { Row } = FieldSet;
@@ -15,156 +25,153 @@ const LOOKUP_DATA = [
 ];
 
 storiesOf('Modal', module)
-  .add('Controlled with knobs', withInfo({
-    text: 'Modal controlled with knobs',
-    inline: false,
-  })(() => (
-    <Modal
-      opened={ boolean('opened', true) }
-      size={ select('size', { '': '(none)', large: 'large' }) }
-      onHide={ action('hide') }
-    >
-      {
-        boolean('header', true) ?
-          <Header title={ text('header title') } closeButton={ boolean('header closeButton') } /> :
+  .add(
+    'Controlled with knobs',
+    withInfo({
+      text: 'Modal controlled with knobs',
+      inline: false,
+    })(() => (
+      <Modal
+        opened={boolean('opened', true)}
+        size={select('size', { '': '(none)', large: 'large' })}
+        onHide={action('hide')}
+      >
+        {boolean('header', true) ? (
+          <Header title={text('header title')} closeButton={boolean('header closeButton')} />
+        ) : (
           []
-      }
-      <Content>
-        <div className='slds-p-around--small'>
+        )}
+        <Content>
+          <div className="slds-p-around--small">
+            <p>
+              Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id
+              consequat veniam incididunt duis in sint irure nisi. Mollit officia cillum Lorem
+              ullamco minim nostrud elit officia tempor esse quis. Cillum sunt ad dolore quis aute
+              consequat ipsum magna exercitation reprehenderit magna. Tempor cupidatat consequat
+              elit dolor adipisicing.
+            </p>
+            <p>
+              Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit officia. Lorem
+              aliqua enim laboris do dolor eiusmod officia. Mollit incididunt nisi consectetur esse
+              laborum eiusmod pariatur proident. Eiusmod et adipisicing culpa deserunt nostrud ad
+              veniam nulla aute est. Labore esse esse cupidatat amet velit id elit consequat minim
+              ullamco mollit enim excepteur ea.
+            </p>
+          </div>
+        </Content>
+        {boolean('footer', true) ? (
+          <Footer directional={boolean('footer directional')}>
+            <Button type="neutral" label="Cancel" />
+            <Button type="brand" label="Done" />
+          </Footer>
+        ) : (
+          []
+        )}
+      </Modal>
+    )),
+  )
+  .add(
+    'Default',
+    withInfo({
+      text: 'Default size modal dialog',
+      inline: false,
+    })(() => (
+      <Modal opened onHide={action('hide')}>
+        <Header title="Default Modal" closeButton />
+        <Content className="slds-p-around--small">
           <p>
-            Sit nulla est ex deserunt exercitation anim occaecat.
-            Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi.
-            Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.
-            Cillum sunt ad dolore quis aute consequat ipsum magna exercitation reprehenderit magna.
-            Tempor cupidatat consequat elit dolor adipisicing.
+            Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id
+            consequat veniam incididunt duis in sint irure nisi. Mollit officia cillum Lorem ullamco
+            minim nostrud elit officia tempor esse quis. Cillum sunt ad dolore quis aute consequat
+            ipsum magna exercitation reprehenderit magna. Tempor cupidatat consequat elit dolor
+            adipisicing.
           </p>
           <p>
-            Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit officia.
-            Lorem aliqua enim laboris do dolor eiusmod officia.
-            Mollit incididunt nisi consectetur esse laborum eiusmod pariatur proident.
-            Eiusmod et adipisicing culpa deserunt nostrud ad veniam nulla aute est.
-            Labore esse esse cupidatat amet velit id elit consequat minim ullamco mollit
-            enim excepteur ea.
+            Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit officia. Lorem
+            aliqua enim laboris do dolor eiusmod officia. Mollit incididunt nisi consectetur esse
+            laborum eiusmod pariatur proident. Eiusmod et adipisicing culpa deserunt nostrud ad
+            veniam nulla aute est. Labore esse esse cupidatat amet velit id elit consequat minim
+            ullamco mollit enim excepteur ea.
           </p>
-        </div>
-      </Content>
-      {
-        boolean('footer', true) ?
-          <Footer directional={ boolean('footer directional') }>
-            <Button type='neutral' label='Cancel' />
-            <Button type='brand' label='Done' />
-          </Footer> :
-          []
-      }
-    </Modal>
-  )))
-  .add('Default', withInfo({
-    text: 'Default size modal dialog',
-    inline: false,
-  })(() => (
-    <Modal
-      opened
-      onHide={ action('hide') }
-    >
-      <Header title='Default Modal' closeButton />
-      <Content className='slds-p-around--small'>
-        <p>
-          Sit nulla est ex deserunt exercitation anim occaecat.
-          Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi.
-          Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.
-          Cillum sunt ad dolore quis aute consequat ipsum magna exercitation reprehenderit magna.
-          Tempor cupidatat consequat elit dolor adipisicing.
-        </p>
-        <p>
-          Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit officia.
-          Lorem aliqua enim laboris do dolor eiusmod officia.
-          Mollit incididunt nisi consectetur esse laborum eiusmod pariatur proident.
-          Eiusmod et adipisicing culpa deserunt nostrud ad veniam nulla aute est.
-          Labore esse esse cupidatat amet velit id elit consequat minim ullamco mollit
-          enim excepteur ea.
-        </p>
-      </Content>
-      <Footer>
-        <Button type='neutral' label='Cancel' />
-        <Button type='brand' label='Done' />
-      </Footer>
-    </Modal>
-  )))
-  .add('Large', withInfo({
-    text: 'Large size modal dialog',
-    inline: false,
-  })(() => (
-    <Modal
-      opened
-      size='large'
-      onHide={ action('hide') }
-    >
-      <Header title='Large Size Modal' closeButton />
-      <Content className='slds-p-around--small'>
-        <p>
-          Sit nulla est ex deserunt exercitation anim occaecat.
-          Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi.
-          Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.
-          Cillum sunt ad dolore quis aute consequat ipsum magna exercitation reprehenderit magna.
-          Tempor cupidatat consequat elit dolor adipisicing.
-        </p>
-        <p>
-          Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit officia.
-          Lorem aliqua enim laboris do dolor eiusmod officia.
-          Mollit incididunt nisi consectetur esse laborum eiusmod pariatur proident.
-          Eiusmod et adipisicing culpa deserunt nostrud ad veniam nulla aute est.
-          Labore esse esse cupidatat amet velit id elit consequat minim ullamco mollit
-          enim excepteur ea.
-        </p>
-      </Content>
-      <Footer>
-        <Button type='neutral' label='Cancel' />
-        <Button type='brand' label='Done' />
-      </Footer>
-    </Modal>
-  )))
-  .add('Form elements', withInfo({
-    text: 'Modal with form elements in the content',
-    inline: false,
-  })(() => (
-    <Modal
-      opened
-      onHide={ action('hide') }
-    >
-      <Header title='Modal Form' closeButton />
-      <Content className='slds-p-around--small'>
-        <Form type='compound'>
-          <FieldSet label='Name'>
+        </Content>
+        <Footer>
+          <Button type="neutral" label="Cancel" />
+          <Button type="brand" label="Done" />
+        </Footer>
+      </Modal>
+    )),
+  )
+  .add(
+    'Large',
+    withInfo({
+      text: 'Large size modal dialog',
+      inline: false,
+    })(() => (
+      <Modal opened size="large" onHide={action('hide')}>
+        <Header title="Large Size Modal" closeButton />
+        <Content className="slds-p-around--small">
+          <p>
+            Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id
+            consequat veniam incididunt duis in sint irure nisi. Mollit officia cillum Lorem ullamco
+            minim nostrud elit officia tempor esse quis. Cillum sunt ad dolore quis aute consequat
+            ipsum magna exercitation reprehenderit magna. Tempor cupidatat consequat elit dolor
+            adipisicing.
+          </p>
+          <p>
+            Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit officia. Lorem
+            aliqua enim laboris do dolor eiusmod officia. Mollit incididunt nisi consectetur esse
+            laborum eiusmod pariatur proident. Eiusmod et adipisicing culpa deserunt nostrud ad
+            veniam nulla aute est. Labore esse esse cupidatat amet velit id elit consequat minim
+            ullamco mollit enim excepteur ea.
+          </p>
+        </Content>
+        <Footer>
+          <Button type="neutral" label="Cancel" />
+          <Button type="brand" label="Done" />
+        </Footer>
+      </Modal>
+    )),
+  )
+  .add(
+    'Form elements',
+    withInfo({
+      text: 'Modal with form elements in the content',
+      inline: false,
+    })(() => (
+      <Modal opened onHide={action('hide')}>
+        <Header title="Modal Form" closeButton />
+        <Content className="slds-p-around--small">
+          <Form type="compound">
+            <FieldSet label="Name">
+              <Row>
+                <Input label="First Name" placeholder="First Name" />
+                <Input label="Last Name" placeholder="Last Name" />
+              </Row>
+            </FieldSet>
+            <FieldSet label="Date Range">
+              <Row>
+                <DateInput label="Start" />
+                <DateInput label="End" />
+              </Row>
+            </FieldSet>
             <Row>
-              <Input label='First Name' placeholder='First Name' />
-              <Input label='Last Name' placeholder='Last Name' />
+              <DateInput label="Closing Date" />
             </Row>
-          </FieldSet>
-          <FieldSet label='Date Range'>
             <Row>
-              <DateInput label='Start' />
-              <DateInput label='End' />
+              <Picklist label="Picklist #1" menuSize="medium">
+                {new Array(10)
+                  .join('_')
+                  .split('')
+                  .map((a, i) => <PicklistItem value={i + 1} label={`Item #${i + 1}`} key={i} />)}
+              </Picklist>
+              <Lookup label="Lookup" data={LOOKUP_DATA} />
             </Row>
-          </FieldSet>
-          <Row>
-            <DateInput label='Closing Date' />
-          </Row>
-          <Row>
-            <Picklist label='Picklist #1' menuSize='medium'>
-              {
-                new Array(10).join('_').split('')
-                  .map((a, i) => (
-                    <PicklistItem value={ i + 1 } label={ `Item #${(i + 1)}` } key={ i } />
-                  ))
-              }
-            </Picklist>
-            <Lookup label='Lookup' data={ LOOKUP_DATA } />
-          </Row>
-        </Form>
-      </Content>
-      <Footer>
-        <Button type='neutral' label='Cancel' />
-        <Button type='brand' label='Done' />
-      </Footer>
-    </Modal>
-  )));
+          </Form>
+        </Content>
+        <Footer>
+          <Button type="neutral" label="Cancel" />
+          <Button type="brand" label="Done" />
+        </Footer>
+      </Modal>
+    )),
+  );

--- a/stories/ModalStories.js
+++ b/stories/ModalStories.js
@@ -19,20 +19,20 @@ const { Header, Content, Footer } = Modal;
 const { Row } = FieldSet;
 
 const LOOKUP_DATA = [
-  { label: 'Account', value: '1', icon: 'standard:account' },
-  { label: 'Contact', value: '2', icon: 'standard:contact' },
-  { label: 'Opportunity', value: '3', icon: 'standard:opportunity' },
+  { icon: 'standard:account', label: 'Account', value: '1' },
+  { icon: 'standard:contact', label: 'Contact', value: '2' },
+  { icon: 'standard:opportunity', label: 'Opportunity', value: '3' },
 ];
 
 storiesOf('Modal', module)
   .add(
     'Controlled with knobs',
     withInfo({
-      text: 'Modal controlled with knobs',
       inline: false,
+      text: 'Modal controlled with knobs',
     })(() => (
       <Modal
-        opened={boolean('opened', true)}
+        isOpened={boolean('isOpened', true)}
         size={select('size', { '': '(none)', large: 'large' })}
         onHide={action('hide')}
       >
@@ -73,10 +73,10 @@ storiesOf('Modal', module)
   .add(
     'Default',
     withInfo({
-      text: 'Default size modal dialog',
       inline: false,
+      text: 'Default size modal dialog',
     })(() => (
-      <Modal opened onHide={action('hide')}>
+      <Modal isOpened onHide={action('hide')}>
         <Header title="Default Modal" closeButton />
         <Content className="slds-p-around--small">
           <p>
@@ -104,10 +104,10 @@ storiesOf('Modal', module)
   .add(
     'Large',
     withInfo({
-      text: 'Large size modal dialog',
       inline: false,
+      text: 'Large size modal dialog',
     })(() => (
-      <Modal opened size="large" onHide={action('hide')}>
+      <Modal isOpened size="large" onHide={action('hide')}>
         <Header title="Large Size Modal" closeButton />
         <Content className="slds-p-around--small">
           <p>
@@ -135,10 +135,10 @@ storiesOf('Modal', module)
   .add(
     'Form elements',
     withInfo({
-      text: 'Modal with form elements in the content',
       inline: false,
+      text: 'Modal with form elements in the content',
     })(() => (
-      <Modal opened onHide={action('hide')}>
+      <Modal isOpened onHide={action('hide')}>
         <Header title="Modal Form" closeButton />
         <Content className="slds-p-around--small">
           <Form type="compound">


### PR DESCRIPTION
- Refactor component to match our code style standard
- Change all `opened` props to `isOpened`
- Separate Modal, ModalHeader, ModalContent, ModalFooter to different files.
- Create test cases for all four components.
- ~~Add `sinon` for simulating function calls for testing~~
    - ~~`npm install` is needed before running `npm run test`~~
- Autofix eslint errors for storybook.
- Add `sort-keys` rule to eslint

Note:
The form modal in storybook looks ugly because it imported some other components such as DatePicker. These components has not been refactored yet.