### PR TITLE
UI-792 Tooltip

### DIFF
--- a/lib/components/Popover/Popover.js
+++ b/lib/components/Popover/Popover.js
@@ -30,7 +30,7 @@ const POPOVER_METHODS = ['click', 'hover'];
 
 const POPOVER_THEMES = ['none', 'info', 'success', 'warning', 'error'];
 
-const propTypes = {
+export const propTypes = {
   children: PropTypes.node,
   /**
    * Header in popover content
@@ -62,7 +62,7 @@ const propTypes = {
   theme: PropTypes.oneOf(POPOVER_THEMES),
 };
 
-const defaultProps = {
+export const defaultProps = {
   header: null,
   body: null,
   isTooltip: false,

--- a/lib/components/Tooltip/Tooltip.js
+++ b/lib/components/Tooltip/Tooltip.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Popover, { propTypes, defaultProps } from '../Popover';
+
+const Tooltip = ({ children, ...props }) => (
+  <Popover {...props} isTooltip>
+    {children}
+  </Popover>
+);
+
+Tooltip.propTypes = propTypes;
+Tooltip.propTypes = defaultProps;
+
+export default Tooltip;

--- a/lib/components/Tooltip/index.js
+++ b/lib/components/Tooltip/index.js
@@ -1,0 +1,3 @@
+import Tooltip from './Tooltip';
+
+export { Tooltip };

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,3 +50,4 @@ export {
   TableRowColumnActions,
 } from './components/Table';
 export { default as Toggle } from './components/Toggle';
+export { Tooltip } from './components/Tooltip';

--- a/stories/TooltipStories.js
+++ b/stories/TooltipStories.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { select } from '@storybook/addon-knobs';
+import { Tooltip, Button } from './../lib';
+
+const TooltipText = `Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+Commodi laudantium molestias reprehenderit nostrum quod natus saepe
+ea corrupti odit minima?
+Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+Commodi laudantium molestias reprehenderit nostrum quod natus saepe
+ea corrupti odit minima?
+`;
+
+const TextCenteredBox = ({ children }) => (
+  <div style={{ textAlign: 'center', width: '100%' }}>{children}</div>
+);
+
+TextCenteredBox.propTypes = {
+  children: propTypes.node,
+};
+
+storiesOf('Tooltip', module)
+  .add(
+    'Controlled with knobs',
+    withInfo('Tooltip controlled with knobs')(() => {
+      const position = select('position', {
+        bottom: 'bottom',
+        'bottom-left': 'bottom-left',
+        'bottom-right': 'bottom-right',
+        left: 'left',
+        'left-bottom': 'left-bottom',
+        'left-top': 'left-top',
+        right: 'right',
+        'right-bottom': 'right-bottom',
+        'right-top': 'right-top',
+        top: 'top',
+        'top-left': 'top-left',
+        'top-right': 'top-right',
+      });
+      const theme = select('theme', {
+        '': '(none)',
+        error: 'error',
+        info: 'info',
+        success: 'success',
+        warning: 'warning',
+      });
+      const method = select('method', {
+        '': '(none)',
+        click: 'click',
+        hover: 'hover',
+      });
+      return (
+        <TextCenteredBox>
+          <Tooltip
+            position={position}
+            method={method}
+            theme={theme}
+            body={TooltipText}
+          >
+            <Button>Trigger</Button>
+          </Tooltip>
+        </TextCenteredBox>
+      );
+    }),
+  )
+  .add(
+    'Trigger methods',
+    withInfo('Tooltip can be triggered by clicking or hovering')(() => (
+      <TextCenteredBox>
+        <Tooltip method="click" position="left" body="I'm body.">
+          <Button>Click to trigger</Button>
+        </Tooltip>
+        <br />
+        <br />
+        <br />
+        <Tooltip method="hover" position="left" body="I'm body.">
+          <Button>Hover to trigger</Button>
+        </Tooltip>
+      </TextCenteredBox>
+    )),
+  )
+  .add(
+    'Themes',
+    withInfo('Use different themes which have different background colors and font colors.')(() => (
+      <TextCenteredBox>
+        <Tooltip method="hover" body="I'm a demo body">
+          <Button>none (default)</Button>
+        </Tooltip>
+        &nbsp;
+        <Tooltip theme="info" method="hover" body="I'm a demo body">
+          <Button>info</Button>
+        </Tooltip>
+        &nbsp;
+        <Tooltip theme="success" method="hover" body="I'm a demo body">
+          <Button>success</Button>
+        </Tooltip>
+        &nbsp;
+        <Tooltip theme="warning" method="hover" body="I'm a demo body">
+          <Button>warning</Button>
+        </Tooltip>
+        &nbsp;
+        <Tooltip theme="error" method="hover" body="I'm a demo body">
+          <Button>error</Button>
+        </Tooltip>
+      </TextCenteredBox>
+    )),
+  );

--- a/stories/index.js
+++ b/stories/index.js
@@ -28,3 +28,4 @@ import './NotificationStories';
 import './PopoverStories';
 import './SpinnerStories';
 import './TextStories';
+import './TooltipStories';


### PR DESCRIPTION
- `Tooltip` is a wrapper for `Popover` with `isTooltip` option on.
- export `propTypes` and `defaultProps` from `Popover`.
- Copy storybook from `Popover` to `Tooltip`. Remove `Tooltip` submenu.